### PR TITLE
Clear graphs

### DIFF
--- a/src/Task/DeleteAllTriples.php
+++ b/src/Task/DeleteAllTriples.php
@@ -11,7 +11,12 @@ class DeleteAllTriples extends VirtuosoTaskBase {
    * Deletes all triples from the backend.
    */
   public function main() {
-    $this->query('DROP ALL;');
+    $graphs = $this->query('SELECT DISTINCT(?g) WHERE { GRAPH ?g { ?s ?p ?o } } ORDER BY ?g');
+    foreach ($graphs as $graph) {
+      if ($graph_uri = $graph->g->getUri()) {
+        $this->query("CLEAR GRAPH <{$graph_uri}>;");
+      }
+    }
   }
 
 }

--- a/src/Task/VirtuosoTaskBase.php
+++ b/src/Task/VirtuosoTaskBase.php
@@ -151,12 +151,14 @@ class VirtuosoTaskBase extends \Task {
    * @param string $query
    *   The string version of the query to execute.
    *
+   * @return \EasyRdf\Sparql\Result|\EasyRdf\Graph
+   *   The result of the query.
    */
   public function query($query) {
     // @todo: The port should be passed as a variable below.
     $connect_string = $this->protocol . $this->dsn . ':' . $this->port . '/sparql';
     $client = new Client($connect_string);
-    $client->query($query);
+    return $client->query($query);
   }
 
   /**


### PR DESCRIPTION
The task that we currently have to clean the sparql backend uses the `DROP ALL` command. However, this does not seem to work.
According to http://vos.openlinksw.com/owiki/wiki/VOS/VirtRemoveTriples
the only ways to nuke the virtuoso backend is through ISQL or the UI. From the http query, we need to build our own procedure. I am doing just that.